### PR TITLE
docs: Make license section use American spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Follow the steps below to build ReVanced Website:
 3. Run `npm i` to install the dependencies
 4. Run `npm run build` to build the project
 
-## 📜 Licence
+## 📜 License
 
 ReVanced Website is licensed under the GPLv3 license. Please see the [license file](LICENSE) for more information.
 [tl;dr](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3) you may copy, distribute and modify ReVanced Website as long as you track changes/dates in source files.


### PR DESCRIPTION
This PR is the same as #334 but change head repository because for some reason history of the main branch and dev branch is diverged

---------------------------------

From #334

This is on my todolist for a very long time, I'll propagate this PR to other revanced repositories after the PR is merged within N+2 days unless requested change.

The license section uses British spelling of the word license ("licence"), which isn't intentional because ReVanced uses American spelling officially. 

Propagator!