### PR TITLE
fix: Handle trailing slashes to fix announcements URL with a slash

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,3 +1,4 @@
 import '../app.css';
 
 export const ssr = true;
+export const trailingSlash = "never";


### PR DESCRIPTION
Issue when adding a / to the end of revanced.app/announcements causing the site to break.
closes #354 